### PR TITLE
This PR adds support for Ubuntu 26 by fixing the bug #3 

### DIFF
--- a/include/dqrobotics/solvers/DQ_QPOASESSolver.h
+++ b/include/dqrobotics/solvers/DQ_QPOASESSolver.h
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2022-2023 DQ Robotics Developers
+(C) Copyright 2011-2026 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -21,6 +21,8 @@ Contributors:
     - Responsible for the original implementation.
 - Quentin Lin (qlin1806@g.ecc.u-tokyo.ac.jp)
     - Added support for equality constraints
+- Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)    
+    - Fixed the bug https://github.com/dqrobotics/cpp-interface-qpoases/issues/3
 */
 #pragma once
 
@@ -34,7 +36,7 @@ using namespace Eigen;
 #include <qpOASES.hpp>
 USING_NAMESPACE_QPOASES
 
-namespace DQ_robotics
+    namespace DQ_robotics
 {
     class DQ_QPOASESSolver: public DQ_QuadraticProgrammingSolver
     {
@@ -46,7 +48,7 @@ namespace DQ_robotics
         //Page 14 of https://www.coin-or.org/qpOASES/doc/3.0/manual.pdf
         int_t maximum_working_set_recalculations_;
 
-        // Equality constraints are handled by means of appended inequality constraints within an equality tolerance threshold.  
+        // Equality constraints are handled by means of appended inequality constraints within an equality tolerance threshold.
         // Initialized to DQ_threshold by default
         double_t equality_constraints_tolerance_ = DQ_threshold;
 
@@ -78,7 +80,7 @@ namespace DQ_robotics
 
     public:
         DQ_QPOASESSolver():
-        qpoases_solve_first_time_(true)
+            qpoases_solve_first_time_(true)
         {
         }
         ~DQ_QPOASESSolver()=default;
@@ -126,7 +128,6 @@ namespace DQ_robotics
             const int PROBLEM_SIZE = H.rows();
             const int INEQUALITY_CONSTRAINT_SIZE = b.size();
             const int EQUALITY_CONSTRAINT_SIZE = beq.size();
-            const int TOTAL_CONSTRAINTS = INEQUALITY_CONSTRAINT_SIZE + EQUALITY_CONSTRAINT_SIZE;
 
             ///Check sizes
             //Objective function
@@ -143,47 +144,46 @@ namespace DQ_robotics
             if(beq.size()!=Aeq.rows())
                 throw std::runtime_error("DQ_QPOASESSolver::solve_quadratic_program(): size of beq="+std::to_string(beq.size())+" should be compatible with rows of Aeq="+std::to_string(Aeq.rows())+".");
 
-
-            MatrixXd A_extended;
-            VectorXd ub_extended;
-
-            if(TOTAL_CONSTRAINTS == 0)
-            {
-                // Create dummy constraints (1x1 matrix) that are always satisfied
-                // This is a workaround for qpOASES requiring at least one constraint
-                A_extended.resize(1, PROBLEM_SIZE);
-                A_extended.setZero();
-                ub_extended.resize(1);
-                ub_extended.setConstant(1e10);  // Large upper bound
-            }
-            else if(EQUALITY_CONSTRAINT_SIZE!=0 && INEQUALITY_CONSTRAINT_SIZE!=0)
+            //Append equality constraints to inequality constraints
+            MatrixXd A_extended = A;
+            VectorXd ub_extended = b;
+            if(EQUALITY_CONSTRAINT_SIZE!=0 && INEQUALITY_CONSTRAINT_SIZE!=0)
             {
                 A_extended.resize(INEQUALITY_CONSTRAINT_SIZE + EQUALITY_CONSTRAINT_SIZE*2, PROBLEM_SIZE);
                 A_extended << A, Aeq, -Aeq;
                 ub_extended.resize(INEQUALITY_CONSTRAINT_SIZE + EQUALITY_CONSTRAINT_SIZE*2);
                 ub_extended << b, beq + VectorXd::Constant(EQUALITY_CONSTRAINT_SIZE, equality_constraints_tolerance_),
-                               -beq + VectorXd::Constant(EQUALITY_CONSTRAINT_SIZE, equality_constraints_tolerance_);
+                    -beq + VectorXd::Constant(EQUALITY_CONSTRAINT_SIZE, equality_constraints_tolerance_);
             } else if(EQUALITY_CONSTRAINT_SIZE!=0)
             {
                 A_extended.resize(EQUALITY_CONSTRAINT_SIZE*2, PROBLEM_SIZE);
                 A_extended << Aeq, -Aeq;
                 ub_extended.resize(EQUALITY_CONSTRAINT_SIZE*2);
                 ub_extended << beq + VectorXd::Constant(EQUALITY_CONSTRAINT_SIZE, equality_constraints_tolerance_),
-                               -beq + VectorXd::Constant(EQUALITY_CONSTRAINT_SIZE, equality_constraints_tolerance_);
+                    -beq + VectorXd::Constant(EQUALITY_CONSTRAINT_SIZE, equality_constraints_tolerance_);
             }
 
             std::vector<double> H_std_vec(H.data(), H.data() + H.rows() * H.cols());
             real_t* H_vec = &H_std_vec[0];
 
-            MatrixXd AT = A_extended.transpose();
-            std::vector<double> A_std_vec(AT.data(), AT.data() + AT.rows() * AT.cols());
-            real_t* A_vec = &A_std_vec[0];
-
             auto g_std_vec = _vectorxd_to_std_vector_double(f);
             real_t* g_vec = &g_std_vec[0];
 
-            auto ub_std_vec = _vectorxd_to_std_vector_double(ub_extended);
-            real_t *ubA_vec = &ub_std_vec[0];
+            real_t* A_vec = nullptr;   // Default for unconstrained cases
+            real_t* ubA_vec = nullptr; // Default for unconstrained cases
+
+            std::vector<double> A_std_vec;
+            std::vector<double> ub_std_vec;
+            if (EQUALITY_CONSTRAINT_SIZE + INEQUALITY_CONSTRAINT_SIZE > 0)
+            {
+                // For constrained cases, we update A_vec and ubA_vec accordingly
+                MatrixXd AT = A_extended.transpose();
+                A_std_vec = std::vector<double>(AT.data(), AT.data() + AT.rows() * AT.cols());
+                A_vec = &A_std_vec[0];
+
+                ub_std_vec = _vectorxd_to_std_vector_double(ub_extended);
+                ubA_vec = &ub_std_vec[0];
+            }
 
             if(qpoases_solve_first_time_)
             {
@@ -214,4 +214,3 @@ namespace DQ_robotics
     };
 
 }
-

--- a/include/dqrobotics/solvers/DQ_QPOASESSolver.h
+++ b/include/dqrobotics/solvers/DQ_QPOASESSolver.h
@@ -126,6 +126,7 @@ namespace DQ_robotics
             const int PROBLEM_SIZE = H.rows();
             const int INEQUALITY_CONSTRAINT_SIZE = b.size();
             const int EQUALITY_CONSTRAINT_SIZE = beq.size();
+            const int TOTAL_CONSTRAINTS = INEQUALITY_CONSTRAINT_SIZE + EQUALITY_CONSTRAINT_SIZE;
 
             ///Check sizes
             //Objective function
@@ -142,10 +143,20 @@ namespace DQ_robotics
             if(beq.size()!=Aeq.rows())
                 throw std::runtime_error("DQ_QPOASESSolver::solve_quadratic_program(): size of beq="+std::to_string(beq.size())+" should be compatible with rows of Aeq="+std::to_string(Aeq.rows())+".");
 
-            //Append equality constraints to inequality constraints
-            auto A_extended = A;
-            auto ub_extended = b;
-            if(EQUALITY_CONSTRAINT_SIZE!=0 && INEQUALITY_CONSTRAINT_SIZE!=0)
+
+            MatrixXd A_extended;
+            VectorXd ub_extended;
+
+            if(TOTAL_CONSTRAINTS == 0)
+            {
+                // Create dummy constraints (1x1 matrix) that are always satisfied
+                // This is a workaround for qpOASES requiring at least one constraint
+                A_extended.resize(1, PROBLEM_SIZE);
+                A_extended.setZero();
+                ub_extended.resize(1);
+                ub_extended.setConstant(1e10);  // Large upper bound
+            }
+            else if(EQUALITY_CONSTRAINT_SIZE!=0 && INEQUALITY_CONSTRAINT_SIZE!=0)
             {
                 A_extended.resize(INEQUALITY_CONSTRAINT_SIZE + EQUALITY_CONSTRAINT_SIZE*2, PROBLEM_SIZE);
                 A_extended << A, Aeq, -Aeq;
@@ -203,3 +214,4 @@ namespace DQ_robotics
     };
 
 }
+


### PR DESCRIPTION
@dqrobotics/developers 

Hi @mmmarinho, 

This PR adds minimal modifications to handle better the unconstrained cases that are failing on Ubuntu 26.04, as reported here https://github.com/dqrobotics/cpp-interface-qpoases/issues/3.

Now, the pointers `A_vec` and `ubA_vec ` are initialized to `nullptr`. In case of constraints, both are updated accordingly.

Kind regards, 

Juancho


PS


Test on Ubuntu 26:

```shell
docker pull ghcr.io/dqrobotics/container:resolute

docker run -it --name=dqrobotics \
--rm --privileged --network=host --ipc=host --env=DISPLAY \
ghcr.io/dqrobotics/container:resolute /bin/bash
```

```shell
cd ~/ && git clone --branch hotfix_ubuntu26 https://github.com/juanjqo/cpp-interface-qpoases.git
cd ~/cpp-interface-qpoases && mkdir -p build
cd ~/cpp-interface-qpoases/build && cmake .. && make && make install

cd ~/ && git clone https://github.com/dqrobotics/cpp-examples.git
cd ~/cpp-examples/cmake/qpoases_interface && mkdir -p build
cd ~/cpp-examples/cmake/qpoases_interface/build && cmake .. && make 
./qpoases_interface
```

Output:
```shell
q_dot is  -0.00311208   0.00617398   0.00304193   -0.0015048   0.00304193 -0.000791966   0.00304193
current equality tolerance: 1e-12
Checking Problem Size: 5
Checking Problem Size: 6
Checking Problem Size: 7
Checking Problem Size: 8
Checking Problem Size: 9
Checking Problem Size: 10

```

- [x] Test on different supported LTE Ubuntu versions  (Ubuntu 22 and 24 are tested on GitHub actions. Ubuntu 26 is tested using Docker)
- [x] Test on macOS (The example is running on macOS Tahoe 26.4)
