### PR TITLE
This PR adds more Ubuntu versions (22,24, and 26) in the runner

### DIFF
--- a/.github/workflows/cpp_build.yml
+++ b/.github/workflows/cpp_build.yml
@@ -4,10 +4,11 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-${{ matrix.ubuntu_version}}
     strategy:
       fail-fast: false
       matrix:
+        ubuntu_version: ['22.04', '24.04', '26.04']
         testbranches: ['master']
 
     steps:


### PR DESCRIPTION


The motivation behind this is that the current version of the cpp-interface-qpoases is failing on Ubuntu 26 but the runner is passing.