### PR TITLE
This PR adds more Ubuntu versions to test on GitHub actions

### DIFF
--- a/.github/workflows/cpp_build.yml
+++ b/.github/workflows/cpp_build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: ['22.04', '24.04', '26.04']
+        ubuntu_version: ['22.04', '24.04'] # Add here '26.04' (Ubuntu resolute) when available
         testbranches: ['master']
 
     steps:

--- a/.github/workflows/cpp_build.yml
+++ b/.github/workflows/cpp_build.yml
@@ -4,10 +4,11 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-${{ matrix.ubuntu_version}}
     strategy:
       fail-fast: false
       matrix:
+        ubuntu_version: ['22.04', '24.04', '26.04']
         testbranches: ['master']
 
     steps:


### PR DESCRIPTION
@dqrobotics/developers 

Hi, @mmmarinho,

This PR adds more Ubuntu versions to test on GitHub actions. Specifically, I just added Ubuntu 22 and 24, since there are no runners for Ubuntu 26 so far.

Kind regards, 

Juancho

